### PR TITLE
Add a CI workflow for a Linux GCC build (and run) test

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -15,13 +15,13 @@ jobs:
     - name: checkout ERF
       uses: actions/checkout@v3
       with:
-        repository: git@github.com:mukul1992/ERF.git
+        repository: mukul1992/ERF.git
         ref: preserve-amrw-coupling
         path: ERF
     - name: checkout amr-wind
       uses: actions/checkout@v3
       with:
-        repository: git@github.com:mukul1992/amr-wind.git
+        repository: mukul1992/amr-wind.git
         ref: new-erf-coupling
         path: amr-wind
 

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -62,4 +62,4 @@ jobs:
         cd ${{runner.workspace}}/erf-amrwind-driver/build
         cd Exec/CouetteFlow
         cp ${{runner.workspace}}/erf-amrwind-driver/Exec/CouetteFlow/input* .
-        ./erf_mb_couette inputs_amrex input_erf1 input_amrwind
+      # ./erf_mb_couette inputs_amrex input_erf1 input_amrwind

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -12,11 +12,14 @@ jobs:
     runs-on: ubuntu-20.04
     # env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual"}
     steps:
-    - uses: actions/checkout@v3
+    - name: checkout ERF
+      uses: actions/checkout@v3
       with:
         repository: git@github.com:mukul1992/ERF.git
         ref: preserve-amrw-coupling
         path: ERF
+    - name: checkout amr-wind
+      uses: actions/checkout@v3
       with:
         repository: git@github.com:mukul1992/amr-wind.git
         ref: new-erf-coupling

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-20.04
     # env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual"}
     steps:
+    - name: checkout driver
+      uses: actions/checkout@v3
+
     - name: checkout ERF
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -2,9 +2,9 @@ name: Linux GCC
 
 on: [push, pull_request]
 
-concurrency:
-  group: ${{ github.ref }}-${{ github.head_ref }}-linux-gcc
-  cancel-in-progress: true
+#concurrency:
+#  group: ${{ github.ref }}-${{ github.head_ref }}-linux-gcc
+#  cancel-in-progress: true
 
 jobs:
   library:
@@ -14,44 +14,38 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        submodules: true
+        repository: git@github.com:mukul1992/ERF.git
+        ref: preserve-amrw-coupling
+        path: ERF
+      with:
+        repository: git@github.com:mukul1992/amr-wind.git
+        ref: new-erf-coupling
+        path: amr-wind
 
     - name: Install Dependencies
-      run: Submodules/AMReX/.github/workflows/dependencies/dependencies.sh
+      run: ${{github.workspace}}/ERF/Submodules/AMReX/.github/workflows/dependencies/dependencies.sh
 
     - name: Configure Project and Generate Build System
       run: |
         cmake \
-          -DCMAKE_INSTALL_PREFIX:PATH=./install \
+          -B${{runner.workspace}}/erf-amrwind-driver/build \
+          -DCMAKE_INSTALL_PREFIX:PATH=${{runner.workspace}}/erf-amrwind-driver/install \
           -DCMAKE_CXX_COMPILER:STRING=mpicxx \
           -DCMAKE_C_COMPILER:STRING=mpicc \
           -DCMAKE_Fortran_COMPILER:STRING=mpifort \
           -DCMAKE_BUILD_TYPE:STRING=Release \
-          -DAMRWIND_HOME:STRING=$HOME/amr-wind \
-          -DERF_HOME:STRING=$HOME/ERF \
+          -DAMRWIND_HOME:STRING=${{github.workspace}}/amr-wind \
+          -DERF_HOME:STRING=${{github.workspace}}/ERF \
           -DERF_DIM:STRING=3 \
           -DERF_ENABLE_MPI:BOOL=ON \
           -DERF_ENABLE_TESTS:BOOL=OFF \
           -DERF_ENABLE_FCOMPARE:BOOL=ON \
           -DERF_ENABLE_DOCUMENTATION:BOOL=OFF \
           -DERF_ENABLE_MULTIBLOCK:BOOL=ON \
-          ..
-        cmake \
-          -B${{runner.workspace}}/ERF/build \
-          -DCMAKE_INSTALL_PREFIX:PATH=${{runner.workspace}}/ERF/install \
-          -DCMAKE_BUILD_TYPE:STRING=Debug \
-          -DERF_DIM:STRING=3 \
-          -DERF_ENABLE_MPI:BOOL=ON \
-          -DERF_ENABLE_TESTS:BOOL=ON \
-          -DERF_ENABLE_ALL_WARNINGS:BOOL=ON \
-          -DERF_ENABLE_FCOMPARE:BOOL=ON \
           ${{github.workspace}};
 
     - name: Compile and Link
       run: |
-        cmake --build ${{runner.workspace}}/ERF/build --parallel 2 --verbose
-
-    - name: CMake Tests # see file ERF/Tests/CTestList.cmake
-      run: |
-        ctest -L regression -VV
-      working-directory: ${{runner.workspace}}/ERF/build
+        cd ${{runner.workspace}}/erf-amrwind-driver/build
+        make -j 8
+      # cmake --build ${{runner.workspace}}/ERF/build --parallel 2 --verbose

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -1,0 +1,57 @@
+name: Linux GCC
+
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.head_ref }}-linux-gcc
+  cancel-in-progress: true
+
+jobs:
+  library:
+    name: GNU@9.3 C++17 Release
+    runs-on: ubuntu-20.04
+    # env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual"}
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: Install Dependencies
+      run: Submodules/AMReX/.github/workflows/dependencies/dependencies.sh
+
+    - name: Configure Project and Generate Build System
+      run: |
+        cmake \
+          -DCMAKE_INSTALL_PREFIX:PATH=./install \
+          -DCMAKE_CXX_COMPILER:STRING=mpicxx \
+          -DCMAKE_C_COMPILER:STRING=mpicc \
+          -DCMAKE_Fortran_COMPILER:STRING=mpifort \
+          -DCMAKE_BUILD_TYPE:STRING=Release \
+          -DAMRWIND_HOME:STRING=$HOME/amr-wind \
+          -DERF_HOME:STRING=$HOME/ERF \
+          -DERF_DIM:STRING=3 \
+          -DERF_ENABLE_MPI:BOOL=ON \
+          -DERF_ENABLE_TESTS:BOOL=OFF \
+          -DERF_ENABLE_FCOMPARE:BOOL=ON \
+          -DERF_ENABLE_DOCUMENTATION:BOOL=OFF \
+          -DERF_ENABLE_MULTIBLOCK:BOOL=ON \
+          ..
+        cmake \
+          -B${{runner.workspace}}/ERF/build \
+          -DCMAKE_INSTALL_PREFIX:PATH=${{runner.workspace}}/ERF/install \
+          -DCMAKE_BUILD_TYPE:STRING=Debug \
+          -DERF_DIM:STRING=3 \
+          -DERF_ENABLE_MPI:BOOL=ON \
+          -DERF_ENABLE_TESTS:BOOL=ON \
+          -DERF_ENABLE_ALL_WARNINGS:BOOL=ON \
+          -DERF_ENABLE_FCOMPARE:BOOL=ON \
+          ${{github.workspace}};
+
+    - name: Compile and Link
+      run: |
+        cmake --build ${{runner.workspace}}/ERF/build --parallel 2 --verbose
+
+    - name: CMake Tests # see file ERF/Tests/CTestList.cmake
+      run: |
+        ctest -L regression -VV
+      working-directory: ${{runner.workspace}}/ERF/build

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -17,12 +17,14 @@ jobs:
       with:
         repository: mukul1992/ERF.git
         ref: preserve-amrw-coupling
+        submodules: true
         path: ERF
     - name: checkout amr-wind
       uses: actions/checkout@v3
       with:
         repository: mukul1992/amr-wind.git
         ref: new-erf-coupling
+        submodules: true
         path: amr-wind
 
     - name: Install Dependencies

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -56,4 +56,10 @@ jobs:
       run: |
         cd ${{runner.workspace}}/erf-amrwind-driver/build
         make -j 8
-      # cmake --build ${{runner.workspace}}/ERF/build --parallel 2 --verbose
+
+    - name: Run Couette flow problem
+      run: |
+        cd ${{runner.workspace}}/erf-amrwind-driver/build
+        cd Exec/CouetteFlow
+        cp ${{runner.workspace}}/erf-amrwind-driver/Exec/CouetteFlow/input* .
+        ./erf_mb_couette inputs_amrex input_erf1 input_amrwind

--- a/.gitignore
+++ b/.gitignore
@@ -10,19 +10,6 @@
 datlog
 log.*
 
-# Ignore everything in Build except the cmake script
-/Build/*
-!/Build/cmake.sh
-!/Build/cmake_cuda.sh
-!/Build/cmake_hip_crusher.sh
-!/Build/cmake_hip.sh
-!/Build/cmake_sycl.sh
-!/Build/cmake_with_moisture.sh
-!/Build/cmake_with_netcdf.sh
-!/Build/cmake_with_poisson.sh
-!/Build/cmake_with_warm_no_precip.sh
-!/Build/cmake_mpi.sh
-
 *build
 
 # Temporary files

--- a/Build/cmake_mpi_debug.sh
+++ b/Build/cmake_mpi_debug.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Example CMake config script for an OSX laptop with OpenMPI
+
+cmake -DCMAKE_INSTALL_PREFIX:PATH=./install \
+      -DCMAKE_CXX_COMPILER:STRING=mpicxx \
+      -DCMAKE_C_COMPILER:STRING=mpicc \
+      -DCMAKE_Fortran_COMPILER:STRING=mpifort \
+      -DMPIEXEC_PREFLAGS:STRING=--oversubscribe \
+      -DCMAKE_BUILD_TYPE:STRING=Debug \
+      -DAMRWIND_HOME:STRING=$HOME/amr-wind \
+      -DERF_HOME:STRING=$HOME/ERF \
+      -DERF_DIM:STRING=3 \
+      -DERF_ENABLE_MPI:BOOL=ON \
+      -DERF_ENABLE_TESTS:BOOL=OFF \
+      -DERF_ENABLE_FCOMPARE:BOOL=ON \
+      -DERF_ENABLE_DOCUMENTATION:BOOL=OFF \
+      -DERF_ENABLE_MULTIBLOCK:BOOL=ON \
+      -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON \
+      .. && make -j8

--- a/README.md
+++ b/README.md
@@ -12,3 +12,5 @@ make -j8
 ```
 
 The ERF and AMR-Wind root directory paths need to provided as the `ERF_HOME` and `AMRWIND_HOME` CMake variables. Template CMake scripts are provided in the `Build` directory for reference.
+
+[![Linux GCC Build and Run](https://github.com/mukul1992/erf-amrwind-driver/actions/workflows/gcc.yml/badge.svg)](https://github.com/mukul1992/erf-amrwind-driver/actions/workflows/gcc.yml)


### PR DESCRIPTION
This is an outcome of the NERSC week hackathon which I used to learn CI workflows from the experienced folks at NERSC.

It checks out specific ERF and AMR-Wind branches from my personal forks as the dependencies for now.

The Couette flow simulation test is commented out for now as it is hanging.