### PR TITLE
AMR-Wind submod update and removing bubble from the AMR-Wind initialization

### DIFF
--- a/Exec/CouetteFlow/input_amrwind
+++ b/Exec/CouetteFlow/input_amrwind
@@ -37,11 +37,7 @@ incflo.do_initial_proj = false
 incflo.initial_iterations = 0
 
 ABL.reference_temperature = 300.0
-ABL.use_bubble = 1
 ABL.stats_output_frequency = 10000000
-ABL.bubble_temp_ratio = 1.05
-ABL.bubble_loc = 500 750 500
-ABL.bubble_radius = 125
 ABL.temperature_heights = 0.0 2000.0
 ABL.temperature_values = 300.0 300.0
 ABL.perturb_temperature = false
@@ -56,7 +52,7 @@ ABL.kappa = .41
 ABL.surface_roughness_z0 = 1e-12
 ABL.bndry_file = "/projects/erf/bperry/ERFcoupling/Exec/ABL/BndryFiles"
 ABL.bndry_io_mode = 1
-ABL.bndry_planes = ylo xlo
+ABL.bndry_planes = ylo xlo yhi xhi
 ABL.bndry_output_start_time = 0.0
 ABL.bndry_var_names = velocity temperature
 ABL.bndry_output_format = erf-multiblock
@@ -70,12 +66,12 @@ ABL.bottom_velocity = 0.0 0.0 0.0
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #        ADAPTIVE MESH REFINEMENT       #
 #.......................................#
-amr.n_cell              = 48 48 48    # Grid cells at coarsest AMRlevel
+amr.n_cell              = 36 48 48    # Grid cells at coarsest AMRlevel
 amr.max_level           = 0           # Max AMR level in hierarchy
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #              GEOMETRY                 #
 #.......................................#
-geometry.prob_lo        =   250.       250.     0.  # Lo corner coordinates
+geometry.prob_lo        =   500.       250.     0.  # Lo corner coordinates
 geometry.prob_hi        =   1250.  1250.  1000.  # Hi corner coordinates
 geometry.is_periodic    =   0   0   0   # Periodicity x y z (0/1)
 incflo.delp             =   0.  0.  0.  # Prescribed (cyclic) pressure gradient

--- a/Exec/CouetteFlow/input_erf1
+++ b/Exec/CouetteFlow/input_erf1
@@ -49,10 +49,10 @@ erf1.spatial_order = 2
 prob.rho_0 = 1.161440171
 prob.Theta0 = 300.0
 prob.use_bubble = 1
-prob.bubble_loc_x = 500
+prob.bubble_loc_x = 250
 prob.bubble_loc_y = 750
 prob.bubble_loc_z = 500
-prob.bubble_radius = 125
+prob.bubble_radius = 100
 prob.bubble_temp_ratio = 1.05
 
 prob.A_0 = 1.0


### PR DESCRIPTION
The AMR-Wind submodule was update multiple times, which included rebasing the upstream changes, and preparing the AMR-Wind `splitting_build` branch to be merged with the main repo.

As part of this the bubble initialization was removed from the AMR-Wind code and hence also from the Coutte flow input file. The bubble is now initialized only in the ERF domain which does not overlap with the AMR-Wind domain.